### PR TITLE
Fixes to bugs in Intermediate.Conformance.100703

### DIFF
--- a/CodeRules/Conformance/IntermediateConformance100703.cs
+++ b/CodeRules/Conformance/IntermediateConformance100703.cs
@@ -112,11 +112,10 @@ namespace ODataValidator.Rule
             if (feed != null && JTokenType.Object == feed.Type)
             {
                 var entities = JsonParserHelper.GetEntries(feed);
-                string propVal = "Edm.String" == primitivePropType ? string.Format("'{0}'", entities[0][primitivePropName].ToString()) : entities[0][primitivePropName].ToString();
+                string propVal = "Edm.String" == primitivePropType ? string.Format("{0}", entities[0][primitivePropName].ToString()) : entities[0][primitivePropName].ToString();
 
                 #region Equal operation on filter.
-                // The comparison operators does not contain "undefined".
-                url = string.Format("{0}?$filter={1} undefined {2}", url, primitivePropName, propVal);
+                url = string.Format("{0}?$filter={1} eq '{2}'", url, primitivePropName, propVal);
                 resp = WebHelper.Get(new Uri(url), Constants.AcceptHeaderJson, RuleEngineSetting.Instance().DefaultMaximumPayloadSize, context.RequestHeaders);
                 detail = new ExtensionRuleResultDetail(this.Name, url, "GET", StringHelper.MergeHeaders(Constants.AcceptHeaderJson, context.RequestHeaders), resp);
 


### PR DESCRIPTION
### Description of the Change
Intermediate.Conformance.100703 will result in `warning`, even if the service is responding correctly. The changes fixes two bugs:
- This test compares two strings, but single quotes in the wrong place would also result false. For example, it would compare `"'Wong'" == "Wong"`. I moved the single quotes out of `propVal` and into `url` to make sure the above example would result in `"Wong" == "Wong"`
- This test would also make a request with the `$filter` comparator `undefined`. For example, `Member?$filter=MemberLastName undefined 'WONG'`. By replacing it with `eq`, it will now correct call `Member?$filter=MemberLastName eq 'WONG'`


### Benefits

This test will now run correctly, logging a conformance result of `success` instead of `warning`.

### Verification Process

I ran this test against our service and looked at the requests to make sure they looked good.