### PR TITLE
Matching  Advanced.Conformance.101101 batch request with OData spec

### DIFF
--- a/CodeRules/Conformance/AdvancedConformance101101.cs
+++ b/CodeRules/Conformance/AdvancedConformance101101.cs
@@ -109,6 +109,7 @@ namespace ODataValidator.Rule
 
             string relativeUrl = new Uri(entityUrl).LocalPath;
             string host = entityUrl.Remove(entityUrl.IndexOf(relativeUrl));
+            string entityById = new Uri(entityUrl).Segments.Last();
 
             string format1Request = string.Format(@"
 --batch_36522ad7-fc75-4b56-8c71-56071383e77b
@@ -131,7 +132,7 @@ Host: {1}
 
 --batch_36522ad7-fc75-4b56-8c71-56071383e77b--", relativeUrl, host);
 
-            string format3Reuqest = string.Format(@"
+            string format3Request = string.Format(@"
 --batch_36522ad7-fc75-4b56-8c71-56071383e77b
 Content-Type: application/http 
 Content-Transfer-Encoding:binary
@@ -139,7 +140,7 @@ Content-Transfer-Encoding:binary
 
 GET {0} HTTP/1.1
 
---batch_36522ad7-fc75-4b56-8c71-56071383e77b--", relativeUrl);
+--batch_36522ad7-fc75-4b56-8c71-56071383e77b--", entityById);
 
             string boundary = @"batch_36522ad7-fc75-4b56-8c71-56071383e77b";
             Response format1Response = WebHelper.BatchOperation(serviceStatus.RootURL.TrimEnd('/') + @"/", format1Request, boundary);
@@ -148,8 +149,8 @@ GET {0} HTTP/1.1
             Response format2Response = WebHelper.BatchOperation(serviceStatus.RootURL.TrimEnd('/') + @"/", format2Request, boundary);
             detail2 = new ExtensionRuleResultDetail(this.Name, feedUrl.TrimEnd('/') + "/$batch", HttpMethod.Post, string.Empty, format2Response, string.Empty, format2Request);
 
-            Response format3Response = WebHelper.BatchOperation(serviceStatus.RootURL.TrimEnd('/') + @"/", format3Reuqest, boundary);
-            detail3 = new ExtensionRuleResultDetail(this.Name, feedUrl.TrimEnd('/') + "/$batch", HttpMethod.Post, string.Empty, format3Response, string.Empty, format3Reuqest);
+            Response format3Response = WebHelper.BatchOperation(serviceStatus.RootURL.TrimEnd('/') + @"/", format3Request, boundary);
+            detail3 = new ExtensionRuleResultDetail(this.Name, feedUrl.TrimEnd('/') + "/$batch", HttpMethod.Post, string.Empty, format3Response, string.Empty, format3Request);
 
             if (format1Response != null && !string.IsNullOrEmpty(format1Response.ResponsePayload))
             {

--- a/CodeRules/Conformance/AdvancedConformance101101.cs
+++ b/CodeRules/Conformance/AdvancedConformance101101.cs
@@ -144,13 +144,13 @@ GET {0} HTTP/1.1
 
             string boundary = @"batch_36522ad7-fc75-4b56-8c71-56071383e77b";
             Response format1Response = WebHelper.BatchOperation(serviceStatus.RootURL.TrimEnd('/') + @"/", format1Request, boundary);
-            detail1 = new ExtensionRuleResultDetail(this.Name, feedUrl.TrimEnd('/') + "/$batch", HttpMethod.Post, string.Empty, format1Response, string.Empty, format1Request);
+            detail1 = new ExtensionRuleResultDetail(this.Name, serviceStatus.RootURL.TrimEnd('/') + "/$batch", HttpMethod.Post, string.Empty, format1Response, string.Empty, format1Request);
 
             Response format2Response = WebHelper.BatchOperation(serviceStatus.RootURL.TrimEnd('/') + @"/", format2Request, boundary);
-            detail2 = new ExtensionRuleResultDetail(this.Name, feedUrl.TrimEnd('/') + "/$batch", HttpMethod.Post, string.Empty, format2Response, string.Empty, format2Request);
+            detail2 = new ExtensionRuleResultDetail(this.Name, serviceStatus.RootURL.TrimEnd('/') + "/$batch", HttpMethod.Post, string.Empty, format2Response, string.Empty, format2Request);
 
             Response format3Response = WebHelper.BatchOperation(serviceStatus.RootURL.TrimEnd('/') + @"/", format3Request, boundary);
-            detail3 = new ExtensionRuleResultDetail(this.Name, feedUrl.TrimEnd('/') + "/$batch", HttpMethod.Post, string.Empty, format3Response, string.Empty, format3Request);
+            detail3 = new ExtensionRuleResultDetail(this.Name, serviceStatus.RootURL.TrimEnd('/') + "/$batch", HttpMethod.Post, string.Empty, format3Response, string.Empty, format3Request);
 
             if (format1Response != null && !string.IsNullOrEmpty(format1Response.ResponsePayload))
             {


### PR DESCRIPTION
### Description of the Change

One of the batch requests incorrectly uses a relative resource path without specifying the host name: 

`GET /path/service/People(1) HTTP/1.1`

This is inconsistent from this OData specification: "Resource path relative to the batch request URI." (http://docs.oasis-open.org/odata/odata/v4.0/errata01/os/complete/part1-protocol/odata-v4.0-errata01-os-part1-protocol-complete.html#_Toc399426857).

This causes a request path that looks like this: 

`https://host:1234/path/service//path/service/People(1)`

This fix will now conform with the OData spec by replacing the incorrect batch request with:

`GET People(1) HTTP/1.1`

There was also a spelling typo that I fixed.